### PR TITLE
Clean up of Docker image and slightly smaller build size.

### DIFF
--- a/docker/Dockerfile.graphcmr
+++ b/docker/Dockerfile.graphcmr
@@ -16,16 +16,18 @@ ENV OPENBLASDIR /usr/lib/x86_64-linux-gnu/openblas
 ENV GPU_TARGET = Kepler Maxwell Pascal Volta
 WORKDIR /opt
 
-RUN apt-get update && apt install -y gfortran  libopenblas-dev && \
+RUN apt-get update && apt-get install -y --no-install-recommends gfortran  libopenblas-dev && \
     wget http://icl.utk.edu/projectsfiles/magma/downloads/magma-2.4.0.tar.gz && \
-    tar xzf magma-2.4.0.tar.gz
+    tar xzf magma-2.4.0.tar.gz && \
+    rm magma-2.4.0.tar.gz
+
 WORKDIR /opt/magma-2.4.0
 RUN cp make.inc-examples/make.inc.openblas make.inc && make -j 8
 
 ENV LD_LIBRARY_PATH /usr/local/magma/lib:$LD_LIBRARY_PATH
 
 WORKDIR /opt
-RUN git clone https://github.com/pytorch/pytorch
+RUN git clone https://github.com/pytorch/pytorch --depth 1 --no-single-branch
 WORKDIR /opt/pytorch
 
 RUN git checkout v${TORCH_VERSION}
@@ -36,7 +38,7 @@ RUN TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX" \
     pip${PYTHON_VERSION} install -v .
 
 WORKDIR /opt
-RUN git clone https://github.com/pytorch/vision.git && cd vision && git checkout v0.2.2 && pip${PYTHON_VERSION} install -v .
+RUN git clone --depth 1 --no-single-branch https://github.com/pytorch/vision.git && cd vision && git checkout v0.2.2 && pip${PYTHON_VERSION} install -v .
 
 RUN pip${PYTHON_VERSION} --no-cache-dir install chumpy tensorboardX neural_renderer_pytorch
 
@@ -45,7 +47,7 @@ RUN if [ -z "${PYTHON_VERSION}" ]; then  pip${PYTHON_VERSION} --no-cache-dir ins
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
 
 WORKDIR /opt
-RUN wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/cdf-dist-all.tar.gz && gunzip cdf-dist-all.tar.gz && tar -xvf cdf-dist-all.tar
+RUN wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/cdf-dist-all.tar.gz && gunzip cdf-dist-all.tar.gz && tar -xvf cdf-dist-all.tar && rm cdf-dist-all.tar
 WORKDIR /cdf37_0-dist
 RUN make OS=linux ENV=gnu CURSES=no all &&  make INSTALLDIR=/usr/local/cdf install && make clean
 

--- a/docker/build
+++ b/docker/build
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-DOCKER_USER=chaneyk
+DOCKER_USER=${USER}
 
 CUDA_VERSION=10.0
 BASE_NUMBER=1.0


### PR DESCRIPTION
Hello, 

I saw this reddit post:
https://www.reddit.com/r/docker/comments/gome1r/advice_on_how_to_reduce_this_image_size/

And thought I would take a shot slightly reducing the docker image size. These are mostly suggestions, as I have no laptop or computer with an Nvidia graphics card right now I was unable to really test this out, so you may want to test these or just take parts of these suggestions.

I add `--no-install-recommends` to the apt install command, this will ensure that only the bare minimum dependencies required to run the software are installed and no recommended packages that are unnecessary are installed. Also when cloning git directories I did a shallow clone of all remote branches by adding this `--depth 1 --no-single-branch` to the git clone commands. If you further want to reduce the size of your git pull I would suggest looking into only cloning an individual branch. This way we only download the source tree and not additional baggage in the form of historical git objects.

https://stackoverflow.com/questions/1778088/how-do-i-clone-a-single-branch-in-git

Next I removed *.tar or *.tar.gz files to clean up after ourselves once the tar files were done extracting.

Finally I made the DOCKER_USER variable in the build script the linux wide environment variable ${USER} so that it works more generally for people who may want to clone and build this repository.

Honestly, I don't know how much smaller these changes will make the image, I suspect not very much. Worth noting though the image you are basing your image off of `chaneyk/daniilidis-group-base:cuda${CUDA_VERSION}-${PYTHON_TAG}-${BASE_NUMBER}` Is not a small image to begin with so you are at a bit of a disadvantage from the get go with your image size.

Here it is compared to the official python and official golang images:
```
~$ docker images
REPOSITORY                      TAG                 IMAGE ID            CREATED             SIZE
python                          latest              4f7cd4269fa9        3 weeks ago         934MB
golang                          latest              2421885b04da        4 weeks ago         809MB
chaneyk/daniilidis-group-base   cuda10.0-py-1.0     10320a5ae102        17 months ago       5.69GB
```


Anyways, hope this helps a little bit. Feel free to close this Pull Request if you do not feel like using any of this directly.